### PR TITLE
Better types in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,15 @@
 declare module 'before-after-hook' {
-  export type HookType = {
-    new (): any
+  export interface HookInstance {
     (name: string, data: any, method: (...any) => any): Promise<any>
     before (name: string, method: (...any) => any): Promise<any>
     error (name: string, method: (...any) => any): Promise<any>
     after (name: string, method: (...any) => any): Promise<any>
     wrap (name: string, method: (...any) => any): Promise<any>
     remove (name: string, beforeHookMethod: (...any) => any): Promise<any>
+  }
+
+  export interface HookType {
+    new (): HookInstance
   }
 
   const Hook: HookType

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,5 +11,5 @@ interface HookType {
   new (): HookInstance
 }
 
-const Hook: HookType
+declare const Hook: HookType
 export = Hook

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 interface HookInstance {
-  (name: string, method: (options: any) => any): Promise<any>
-  (name: string, options: any, method: (options: any) => any): Promise<any>
+  (name: string | string[], method: (options: any) => any): Promise<any>
+  (name: string | string[], options: any, method: (options: any) => any): Promise<any>
   before (name: string, method: (options: any) => any): HookInstance
   error (name: string, method: (options: any) => any): HookInstance
   after (name: string, method: (options: any) => any): HookInstance

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,17 +1,15 @@
-declare module 'before-after-hook' {
-  export interface HookInstance {
-    (name: string, data: any, method: (...any) => any): Promise<any>
-    before (name: string, method: (...any) => any): Promise<any>
-    error (name: string, method: (...any) => any): Promise<any>
-    after (name: string, method: (...any) => any): Promise<any>
-    wrap (name: string, method: (...any) => any): Promise<any>
-    remove (name: string, beforeHookMethod: (...any) => any): Promise<any>
-  }
-
-  export interface HookType {
-    new (): HookInstance
-  }
-
-  const Hook: HookType
-  export default Hook
+interface HookInstance {
+  (name: string, data: any, method: (...any) => any): Promise<any>
+  before (name: string, method: (...any) => any): Promise<any>
+  error (name: string, method: (...any) => any): Promise<any>
+  after (name: string, method: (...any) => any): Promise<any>
+  wrap (name: string, method: (...any) => any): Promise<any>
+  remove (name: string, beforeHookMethod: (...any) => any): Promise<any>
 }
+
+interface HookType {
+  new (): HookInstance
+}
+
+const Hook: HookType
+export = Hook

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,31 @@
 interface HookInstance {
+  /**
+   * Invoke before and after hooks.
+   */
   (name: string | string[], method: (options: any) => any): Promise<any>
+  /**
+   * Invoke before and after hooks.
+   */
   (name: string | string[], options: any, method: (options: any) => any): Promise<any>
+  /**
+   * Add before hook for given name. Returns `hook` instance for chaining.
+   */
   before (name: string, method: (options: any) => any): HookInstance
+  /**
+   * Add error hook for given name. Returns `hook` instance for chaining.
+   */
   error (name: string, method: (options: any) => any): HookInstance
+  /**
+   * Add after hook for given name. Returns `hook` instance for chaining.
+   */
   after (name: string, method: (options: any) => any): HookInstance
+  /**
+   * Add wrap hook for given name. Returns `hook` instance for chaining.
+   */
   wrap (name: string, method: (options: any) => any): HookInstance
+  /**
+   * Removes hook for given name. Returns `hook` instance for chaining.
+   */
   remove (name: string, beforeHookMethod: (options: any) => any): HookInstance
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,11 @@
 interface HookInstance {
-  (name: string, data: any, method: (...any) => any): Promise<any>
-  before (name: string, method: (...any) => any): Promise<any>
-  error (name: string, method: (...any) => any): Promise<any>
-  after (name: string, method: (...any) => any): Promise<any>
-  wrap (name: string, method: (...any) => any): Promise<any>
-  remove (name: string, beforeHookMethod: (...any) => any): Promise<any>
+  (name: string, method: (options: any) => any): Promise<any>
+  (name: string, options: any, method: (options: any) => any): Promise<any>
+  before (name: string, method: (options: any) => any): Promise<any>
+  error (name: string, method: (options: any) => any): Promise<any>
+  after (name: string, method: (options: any) => any): Promise<any>
+  wrap (name: string, method: (options: any) => any): Promise<any>
+  remove (name: string, beforeHookMethod: (options: any) => any): Promise<any>
 }
 
 interface HookType {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,11 @@
 interface HookInstance {
   (name: string, method: (options: any) => any): Promise<any>
   (name: string, options: any, method: (options: any) => any): Promise<any>
-  before (name: string, method: (options: any) => any): Promise<any>
-  error (name: string, method: (options: any) => any): Promise<any>
-  after (name: string, method: (options: any) => any): Promise<any>
-  wrap (name: string, method: (options: any) => any): Promise<any>
-  remove (name: string, beforeHookMethod: (options: any) => any): Promise<any>
+  before (name: string, method: (options: any) => any): HookInstance
+  error (name: string, method: (options: any) => any): HookInstance
+  after (name: string, method: (options: any) => any): HookInstance
+  wrap (name: string, method: (options: any) => any): HookInstance
+  remove (name: string, beforeHookMethod: (options: any) => any): HookInstance
 }
 
 interface HookType {


### PR DESCRIPTION
I've played around with these types a bit more, and realized that my first PR (#48) was the bare minimum - this PR adds much better type support, so in VS Code (for example) it's aware of the methods available on the hook instance:

<img width="768" alt="image" src="https://user-images.githubusercontent.com/10660468/50533580-99350000-0afa-11e9-94dc-95ddc7fed488.png">

If you're curious, this was tested by running `npm link` in my local clone of this repo, then `npm link before-after-hook` in a testing project. I encourage you to try it out yourself!

Now we can add some `/** */` comments to show up in those Intellisense annotations! I can do those in a followup if you're interested - but it'd be cool to try to generate them from the README docs (or the other way around). For later though!