### PR TITLE
fix: when no hooks are registered pass options through

### DIFF
--- a/lib/register.js
+++ b/lib/register.js
@@ -22,7 +22,11 @@ function register (state, name, options, method) {
 
   return Promise.resolve()
     .then(function () {
-      return (state.registry[name] || []).reduce(function (method, registered) {
+      if (!state.registry[name]) {
+        return method(options)
+      }
+
+      return (state.registry[name]).reduce(function (method, registered) {
         return registered.hook.bind(null, method, options)
       }, method)()
     })

--- a/test/integration/hook-test.js
+++ b/test/integration/hook-test.js
@@ -51,5 +51,15 @@ test('hook(name, options, method)', function (group) {
       .catch(t.error)
   })
 
+  group.test('no handlers defined (#51)', function (t) {
+    var hook = new Hook()
+    var options = { foo: 'bar' }
+
+    hook('test', options, function (_options) {
+      t.deepLooseEqual(options, _options)
+      t.end()
+    })
+  })
+
   group.end()
 })


### PR DESCRIPTION
When there are no hooks registered the `state.registry` ended up empty. 
As I don't know the inners of this project, this probably needs some thought.
Maybe needs more tests to check if make the method will be called multiple times as a side effect. 

closes #50