### PR TITLE
Improve TypeScript Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ hookCollection('add', function (record) {
 
 ### hookCollection.before()
 
-Add before hook for given name. Returns `hookCollection` instance for chaining.
+Add before hook for given name.
 
 ```js
 hookCollection.before(name, method)
@@ -316,7 +316,7 @@ hookCollection.before('save', function validate (record) {
 
 ### hookCollection.error()
 
-Add error hook for given name. Returns `hookCollection` instance for chaining.
+Add error hook for given name.
 
 ```js
 hookCollection.error(name, method)
@@ -362,7 +362,7 @@ hookCollection.error('save', function (error, options) {
 
 ### hookCollection.after()
 
-Add after hook for given name. Returns `hook` instance for chaining.
+Add after hook for given name.
 
 ```js
 hookCollection.after(name, method)
@@ -408,7 +408,7 @@ hookCollection.after('save', function (result, options) {
 
 ### hookCollection.wrap()
 
-Add wrap hook for given name. Returns `hookCollection` instance for chaining.
+Add wrap hook for given name.
 
 ```js
 hookCollection.wrap(name, method)
@@ -468,7 +468,7 @@ See also: [Test mock example](examples/test-mock-example.md)
 
 ### hookCollection.remove()
 
-Removes hook for given name. Returns `hookCollection` instance for chaining.
+Removes hook for given name.
 
 ```js
 hookCollection.remove(name, hookMethod)

--- a/index.d.ts
+++ b/index.d.ts
@@ -120,7 +120,7 @@ declare module "before-after-hook" {
     /**
      * Creates a nameless hook that allows passing down typings for the options
      */
-    Singular: {new <T>(): HookSingular<T>}
+    Singular: {new <T = any>(): HookSingular<T>}
 
     /**
      * Creates a hook collection
@@ -128,7 +128,7 @@ declare module "before-after-hook" {
     Collection: {new (): HookCollection}
   }
 
-  export const Singular: {new <T>(): HookSingular<T>}
+  export const Singular: {new <T = any>(): HookSingular<T>}
   export const Collection: {new (): HookCollection}
 
   export = Hook

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,16 +1,16 @@
 type HookMethod<O, R> = (options: O) => R | Promise<R>
 
 type BeforeHook<O> = (options: O) => void
-type ErrorHook<O> = (error: any, options: O) => void
+type ErrorHook<O, E> = (error: E, options: O) => void
 type AfterHook<O, R> = (result: R, options: O) => void
 type WrapHook<O, R> = (
   hookMethod: HookMethod<O, R>,
   options: O
 ) => R | Promise<R>
 
-type AnyHook<O, R> =
+type AnyHook<O, R, E> =
   | BeforeHook<O>
-  | ErrorHook<O>
+  | ErrorHook<O, E>
   | AfterHook<O, R>
   | WrapHook<O, R>
 
@@ -30,7 +30,7 @@ export interface HookCollection {
   /**
    * Add `error` hook for given `name`
    */
-  error(name: string, errorHook: ErrorHook<any>): void
+  error(name: string, errorHook: ErrorHook<any, any>): void
   /**
    * Add `after` hook for given `name`
    */
@@ -42,10 +42,10 @@ export interface HookCollection {
   /**
    * Remove added hook for given `name`
    */
-  remove(name: string, hook: AnyHook<any, any>): void
+  remove(name: string, hook: AnyHook<any, any, any>): void
 }
 
-export interface HookSingular<O, R> {
+export interface HookSingular<O, R, E> {
   /**
    * Invoke before and after hooks
    */
@@ -57,7 +57,7 @@ export interface HookSingular<O, R> {
   /**
    * Add `error` hook
    */
-  error(errorHook: ErrorHook<O>): void
+  error(errorHook: ErrorHook<O, E>): void
   /**
    * Add `after` hook
    */
@@ -69,11 +69,11 @@ export interface HookSingular<O, R> {
   /**
    * Remove added hook
    */
-  remove(hook: AnyHook<O, R>): void
+  remove(hook: AnyHook<O, R, E>): void
 }
 
 type Collection = new () => HookCollection
-type Singular = new <O = any, R = any>() => HookSingular<O, R>
+type Singular = new <O = any, R = any, E = any>() => HookSingular<O, R, E>
 
 interface Hook {
   new (): HookCollection

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,21 +32,9 @@ declare module "before-after-hook" {
 
   export interface HookSingular<T> {
     /**
-     * Invoke before and after hooks without options
+     * Invoke before and after hooks
      */
-    (method: (options: T) => T | null | void): Promise<T>
-    /**
-     * Invoke before and after hooks without options
-     */
-    (method: (options: T) => Promise<T | null | void>): Promise<T>
-    /**
-     * Invoke before and after hooks with options
-     */
-    (method: (options: T) => T | null | void, options: T): Promise<T>
-    /**
-     * Invoke before and after hooks with options
-     */
-    (method: (options: T) => Promise<T | null | void>, options: T): Promise<T>
+    (method: (options: T) => void | T | Promise<void | T>, options?: T): Promise<T>
 
     /**
      * Add before hook. Returns `UnnamedHook` instance for chaining.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,83 +1,96 @@
-type HookMethod<O = any, R = any> = (options: O) => R | Promise<R>
+type HookMethod<O, R> = (options: O) => R | Promise<R>
 
 type BeforeHook<O> = (options: O) => void
 type ErrorHook<O> = (error: any, options: O) => void
 type AfterHook<O, R> = (result: R, options: O) => void
-type WrapHook<O, R> = (hookMethod: HookMethod<O, R>, options: O) => R | Promise<R>
+type WrapHook<O, R> = (
+  hookMethod: HookMethod<O, R>,
+  options: O
+) => R | Promise<R>
 
-type AnyHook<O, R> = BeforeHook<O> | ErrorHook<O> | AfterHook<O, R> | WrapHook<O, R>
+type AnyHook<O, R> =
+  | BeforeHook<O>
+  | ErrorHook<O>
+  | AfterHook<O, R>
+  | WrapHook<O, R>
 
-declare module "before-after-hook" {
-  export interface HookCollection {
-    /**
-     * Invoke before and after hooks
-     */
-    (name: string | string[], hookMethod: HookMethod, options?: any): Promise<any>
-    /**
-     * Add `before` hook for given `name`
-     */
-    before(name: string, beforeHook: BeforeHook<any>): void
-    /**
-     * Add `error` hook for given `name`
-     */
-    error(name: string, errorHook: ErrorHook<any>): void
-    /**
-     * Add `after` hook for given `name`
-     */
-    after(name: string, afterHook: AfterHook<any, any>): void
-    /**
-     * Add `wrap` hook for given `name`
-     */
-    wrap(name: string, wrapHook: WrapHook<any, any>): void
-    /**
-     * Remove added hook for given `name`
-     */
-    remove(name: string, hook: AnyHook<any, any>): void
-  }
-
-  export interface HookSingular<O, R> {
-    /**
-     * Invoke before and after hooks
-     */
-    (hookMethod: HookMethod<O, R>, options?: O): Promise<R>
-    /**
-     * Add `before` hook
-     */
-    before(beforeHook: BeforeHook<O>): void;
-    /**
-     * Add `error` hook
-     */
-    error(errorHook: ErrorHook<O>): void;
-    /**
-     * Add `after` hook
-     */
-    after(afterHook: AfterHook<O, R>): void;
-    /**
-     * Add `wrap` hook
-     */
-    wrap(wrapHook: WrapHook<O, R>): void;
-    /**
-     * Remove added hook
-     */
-    remove(hook: AnyHook<O, R>): void;
-  }
-
-  export const Hook: {
-    new (): HookCollection
-
-    /**
-     * Creates a nameless hook that allows passing down typings for the options
-     */
-    Singular: {new <O = any, R = any>(): HookSingular<O, R>}
-
-    /**
-     * Creates a hook collection
-     */
-    Collection: {new (): HookCollection}
-  }
-
-  export const Singular: {new <O = any, R = any>(): HookSingular<O, R>}
-  export const Collection: {new (): HookCollection}
-
-  export = Hook
+interface HookCollection {
+  /**
+   * Invoke before and after hooks
+   */
+  (
+    name: string | string[],
+    hookMethod: HookMethod<any, any>,
+    options?: any
+  ): Promise<any>
+  /**
+   * Add `before` hook for given `name`
+   */
+  before(name: string, beforeHook: BeforeHook<any>): void
+  /**
+   * Add `error` hook for given `name`
+   */
+  error(name: string, errorHook: ErrorHook<any>): void
+  /**
+   * Add `after` hook for given `name`
+   */
+  after(name: string, afterHook: AfterHook<any, any>): void
+  /**
+   * Add `wrap` hook for given `name`
+   */
+  wrap(name: string, wrapHook: WrapHook<any, any>): void
+  /**
+   * Remove added hook for given `name`
+   */
+  remove(name: string, hook: AnyHook<any, any>): void
 }
+
+interface HookSingular<O, R> {
+  /**
+   * Invoke before and after hooks
+   */
+  (hookMethod: HookMethod<O, R>, options?: O): Promise<R>
+  /**
+   * Add `before` hook
+   */
+  before(beforeHook: BeforeHook<O>): void
+  /**
+   * Add `error` hook
+   */
+  error(errorHook: ErrorHook<O>): void
+  /**
+   * Add `after` hook
+   */
+  after(afterHook: AfterHook<O, R>): void
+  /**
+   * Add `wrap` hook
+   */
+  wrap(wrapHook: WrapHook<O, R>): void
+  /**
+   * Remove added hook
+   */
+  remove(hook: AnyHook<O, R>): void
+}
+
+type Collection = new () => HookCollection
+type Singular = new <O = any, R = any>() => HookSingular<O, R>
+
+interface Hook {
+  new (): HookCollection
+
+  /**
+   * Creates a collection of hooks
+   */
+  Collection: Collection
+
+  /**
+   * Creates a nameless hook that supports strict typings
+   */
+  Singular: Singular
+}
+
+export const Hook: Hook
+export const Collection: Collection
+export const Singular: Singular
+
+export default Hook

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,40 +1,38 @@
 type HookMethod<O = any, R = any> = (options: O) => R | Promise<R>
 
-type SingularBeforeHook<O> = (options: O) => void
-type SingularErrorHook<O> = (error: any, options: O) => void
-type SingularAfterHook<O, R> = (result: R, options: O) => void
-type SingularWrapHook<O, R> = (hookMethod: HookMethod<O, R>, options: O) => R | Promise<R>
+type BeforeHook<O> = (options: O) => void
+type ErrorHook<O> = (error: any, options: O) => void
+type AfterHook<O, R> = (result: R, options: O) => void
+type WrapHook<O, R> = (hookMethod: HookMethod<O, R>, options: O) => R | Promise<R>
+
+type AnyHook<O, R> = BeforeHook<O> | ErrorHook<O> | AfterHook<O, R> | WrapHook<O, R>
 
 declare module "before-after-hook" {
   export interface HookCollection {
     /**
-     * Invoke before and after hooks.
+     * Invoke before and after hooks
      */
-    (name: string | string[], method: (options: any) => Promise<any> | any): Promise<any>
+    (name: string | string[], hookMethod: HookMethod, options?: any): Promise<any>
     /**
-     * Invoke before and after hooks.
+     * Add `before` hook for given `name`
      */
-    (name: string | string[], method: (options: any) => Promise<any> | any, options: any): Promise<any>
+    before(name: string, beforeHook: BeforeHook<any>): void
     /**
-     * Add before hook for given name. Returns `hook` instance for chaining.
+     * Add `error` hook for given `name`
      */
-    before (name: string, method: (options: any) => Promise<any> | any): HookCollection
+    error(name: string, errorHook: ErrorHook<any>): void
     /**
-     * Add error hook for given name. Returns `hook` instance for chaining.
+     * Add `after` hook for given `name`
      */
-    error (name: string, method: (options: any) => Promise<any> | any): HookCollection
+    after(name: string, afterHook: AfterHook<any, any>): void
     /**
-     * Add after hook for given name. Returns `hook` instance for chaining.
+     * Add `wrap` hook for given `name`
      */
-    after (name: string, method: (options: any) => Promise<any> | any): HookCollection
+    wrap(name: string, wrapHook: WrapHook<any, any>): void
     /**
-     * Add wrap hook for given name. Returns `hook` instance for chaining.
+     * Remove added hook for given `name`
      */
-    wrap (name: string, method: (options: any) => Promise<any> | any): HookCollection
-    /**
-     * Removes hook for given name. Returns `hook` instance for chaining.
-     */
-    remove (name: string, beforeHookMethod: (options: any) => Promise<any> | any): HookCollection
+    remove(name: string, hook: AnyHook<any, any>): void
   }
 
   export interface HookSingular<O, R> {
@@ -42,33 +40,26 @@ declare module "before-after-hook" {
      * Invoke before and after hooks
      */
     (hookMethod: HookMethod<O, R>, options?: O): Promise<R>
-
     /**
      * Add `before` hook
      */
-    before(beforeHook: SingularBeforeHook<O>): void;
-
+    before(beforeHook: BeforeHook<O>): void;
     /**
      * Add `error` hook
      */
-    error(errorHook: SingularErrorHook<O>): void;
-
+    error(errorHook: ErrorHook<O>): void;
     /**
      * Add `after` hook
      */
-    after(afterHook: SingularAfterHook<O, R>): void;
-
+    after(afterHook: AfterHook<O, R>): void;
     /**
      * Add `wrap` hook
      */
-    wrap(wrapHook: SingularWrapHook<O, R>): void;
-
+    wrap(wrapHook: WrapHook<O, R>): void;
     /**
      * Remove added hook
      */
-    remove(
-      hook: SingularBeforeHook<O> | SingularErrorHook<O> | SingularAfterHook<O, R> | SingularWrapHook<O, R>
-    ): void;
+    remove(hook: AnyHook<O, R>): void;
   }
 
   export const Hook: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,71 +34,41 @@ declare module "before-after-hook" {
     /**
      * Invoke before and after hooks
      */
-    (method: (options: T) => void | T | Promise<void | T>, options?: T): Promise<T>
+    (hookMethod: (options: T) => void | T | Promise<void | T>, options?: T): Promise<T>
 
     /**
      * Add before hook. Returns `UnnamedHook` instance for chaining.
      */
     before(
-      beforeFn: (options: T) => T | null | void
-    ): HookSingular<T>;
-    /**
-     * Add before hook. Returns `UnnamedHook` instance for chaining.
-     */
-    before(
-      beforeFn: (options: T) => Promise<T | null | void>
+      beforeHook: (options: T) => void | T | Promise<void | T>
     ): HookSingular<T>;
 
     /**
      * Add error hook. Returns `UnnamedHook` instance for chaining.
      */
     error(
-      errorFn: (options: T) => T | null | void
-    ): HookSingular<T>;
-    /**
-     * Add error hook. Returns `UnnamedHook` instance for chaining.
-     */
-    error(
-      errorFn: (options: T) => Promise<T | null | void>
+      errorHook: (options: T) => void | T | Promise<void | T>
     ): HookSingular<T>;
 
     /**
      * Add after hook. Returns `UnnamedHook` instance for chaining.
      */
     after(
-      afterFn: (options: T) => T | null | void
-    ): HookSingular<T>;
-    /**
-     * Add after hook. Returns `UnnamedHook` instance for chaining.
-     */
-    after(
-      afterFn: (options: T) => Promise<T | null | void>
+      afterHook: (options: T) => void | T | Promise<void | T>
     ): HookSingular<T>;
 
     /**
      * Add wrap hook. Returns `UnnamedHook` instance for chaining.
      */
     wrap(
-      wrapFn: (options: T) => T | null | void
-    ): HookSingular<T>;
-    /**
-     * Add wrap hook. Returns `UnnamedHook` instance for chaining.
-     */
-    wrap(
-      wrapFn: (options: T) => Promise<T | null | void>
+      wrapHook: (options: T) => void | T | Promise<void | T>
     ): HookSingular<T>;
 
     /**
      * Removes hook. Returns `UnnamedHook` instance for chaining.
      */
     remove(
-      beforeHookMethod: (options: T) => T | null | void
-    ): HookSingular<T>;
-    /**
-     * Removes hook. Returns `UnnamedHook` instance for chaining.
-     */
-    remove(
-      beforeHookMethod: (options: T) => Promise<T | null | void>
+      hookMethod: (options: T) => void | T | Promise<void | T>
     ): HookSingular<T>;
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,10 @@
+type HookMethod<O = any, R = any> = (options: O) => R | Promise<R>
+
+type SingularBeforeHook<O> = (options: O) => void
+type SingularErrorHook<O> = (error: any, options: O) => void
+type SingularAfterHook<O, R> = (result: R, options: O) => void
+type SingularWrapHook<O, R> = (hookMethod: HookMethod<O, R>, options: O) => R | Promise<R>
+
 declare module "before-after-hook" {
   export interface HookCollection {
     /**
@@ -30,46 +37,46 @@ declare module "before-after-hook" {
     remove (name: string, beforeHookMethod: (options: any) => Promise<any> | any): HookCollection
   }
 
-  export interface HookSingular<T> {
+  export interface HookSingular<O, R> {
     /**
      * Invoke before and after hooks
      */
-    (hookMethod: (options: T) => void | T | Promise<void | T>, options?: T): Promise<T>
+    (hookMethod: HookMethod<O, R>, options?: O): Promise<R>
 
     /**
      * Add before hook. Returns `UnnamedHook` instance for chaining.
      */
     before(
-      beforeHook: (options: T) => void | T | Promise<void | T>
-    ): HookSingular<T>;
+      beforeHook: SingularBeforeHook<O>
+    ): HookSingular<O, R>;
 
     /**
      * Add error hook. Returns `UnnamedHook` instance for chaining.
      */
     error(
-      errorHook: (options: T) => void | T | Promise<void | T>
-    ): HookSingular<T>;
+      errorHook: SingularErrorHook<O>
+    ): HookSingular<O, R>;
 
     /**
      * Add after hook. Returns `UnnamedHook` instance for chaining.
      */
     after(
-      afterHook: (options: T) => void | T | Promise<void | T>
-    ): HookSingular<T>;
+      afterHook: SingularAfterHook<O, R>
+    ): HookSingular<O, R>;
 
     /**
      * Add wrap hook. Returns `UnnamedHook` instance for chaining.
      */
     wrap(
-      wrapHook: (options: T) => void | T | Promise<void | T>
-    ): HookSingular<T>;
+      wrapHook: SingularWrapHook<O, R>
+    ): HookSingular<O, R>;
 
     /**
      * Removes hook. Returns `UnnamedHook` instance for chaining.
      */
     remove(
-      hookMethod: (options: T) => void | T | Promise<void | T>
-    ): HookSingular<T>;
+      hook: SingularBeforeHook<O> | SingularErrorHook<O> | SingularAfterHook<O, R> | SingularWrapHook<O, R>
+    ): HookSingular<O, R>;
   }
 
   export const Hook: {
@@ -78,7 +85,7 @@ declare module "before-after-hook" {
     /**
      * Creates a nameless hook that allows passing down typings for the options
      */
-    Singular: {new <T = any>(): HookSingular<T>}
+    Singular: {new <O = any, R = any>(): HookSingular<O, R>}
 
     /**
      * Creates a hook collection
@@ -86,7 +93,7 @@ declare module "before-after-hook" {
     Collection: {new (): HookCollection}
   }
 
-  export const Singular: {new <T = any>(): HookSingular<T>}
+  export const Singular: {new <O = any, R = any>(): HookSingular<O, R>}
   export const Collection: {new (): HookCollection}
 
   export = Hook

--- a/index.d.ts
+++ b/index.d.ts
@@ -44,39 +44,31 @@ declare module "before-after-hook" {
     (hookMethod: HookMethod<O, R>, options?: O): Promise<R>
 
     /**
-     * Add before hook. Returns `UnnamedHook` instance for chaining.
+     * Add `before` hook
      */
-    before(
-      beforeHook: SingularBeforeHook<O>
-    ): HookSingular<O, R>;
+    before(beforeHook: SingularBeforeHook<O>): void;
 
     /**
-     * Add error hook. Returns `UnnamedHook` instance for chaining.
+     * Add `error` hook
      */
-    error(
-      errorHook: SingularErrorHook<O>
-    ): HookSingular<O, R>;
+    error(errorHook: SingularErrorHook<O>): void;
 
     /**
-     * Add after hook. Returns `UnnamedHook` instance for chaining.
+     * Add `after` hook
      */
-    after(
-      afterHook: SingularAfterHook<O, R>
-    ): HookSingular<O, R>;
+    after(afterHook: SingularAfterHook<O, R>): void;
 
     /**
-     * Add wrap hook. Returns `UnnamedHook` instance for chaining.
+     * Add `wrap` hook
      */
-    wrap(
-      wrapHook: SingularWrapHook<O, R>
-    ): HookSingular<O, R>;
+    wrap(wrapHook: SingularWrapHook<O, R>): void;
 
     /**
-     * Removes hook. Returns `UnnamedHook` instance for chaining.
+     * Remove added hook
      */
     remove(
       hook: SingularBeforeHook<O> | SingularErrorHook<O> | SingularAfterHook<O, R> | SingularWrapHook<O, R>
-    ): HookSingular<O, R>;
+    ): void;
   }
 
   export const Hook: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,7 @@ type AnyHook<O, R> =
   | AfterHook<O, R>
   | WrapHook<O, R>
 
-interface HookCollection {
+export interface HookCollection {
   /**
    * Invoke before and after hooks
    */
@@ -45,7 +45,7 @@ interface HookCollection {
   remove(name: string, hook: AnyHook<any, any>): void
 }
 
-interface HookSingular<O, R> {
+export interface HookSingular<O, R> {
   /**
    * Invoke before and after hooks
    */

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,15 @@
             "has-flag": "^3.0.0"
           }
         }
+      },
+    },
+    "@babel/runtime": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.4.tgz",
+      "integrity": "sha512-Na84uwyImZZc3FKf4aUF1tysApzwf3p2yuFBIyBfbzT5glzKTdvYI4KVW4kcgjrzoGUjC7w3YyCHcJKaRxsr2Q==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -8772,6 +8781,12 @@
         }
       }
     },
+    "regenerator-runtime": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
+      "dev": true
+    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -10019,7 +10034,10 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/tap-yaml/-/tap-yaml-0.2.0.tgz",
       "integrity": "sha512-Cy5RfopxF1qhE+sds0XOMeKegT80NVV43JAMsD7Be9l/tjRPO5YzewOpQq8jUnOngI4GOiOgG2M7GB772hIVwA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "yaml": "github:isaacs/yaml#built"
+      }
     },
     "tape": {
       "version": "4.9.1",
@@ -10217,6 +10235,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
       "dev": true
     },
     "uglify-js": {
@@ -10550,6 +10574,14 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
       "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
       "dev": true
+    },
+    "yaml": {
+      "version": "github:isaacs/yaml#bd3a3116f21910ab79635b535494609f8794084a",
+      "from": "github:isaacs/yaml#built",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.3.4"
+      }
     },
     "yargs": {
       "version": "3.32.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
             "has-flag": "^3.0.0"
           }
         }
-      },
+      }
     },
     "@babel/runtime": {
       "version": "7.5.4",
@@ -1791,7 +1791,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
@@ -3486,7 +3486,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -3630,7 +3630,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -4366,7 +4366,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
@@ -4413,7 +4413,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -4422,7 +4422,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -9115,7 +9115,7 @@
             },
             "get-stream": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
               "dev": true
             }
@@ -9740,7 +9740,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -9755,7 +9755,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -10036,7 +10036,7 @@
       "integrity": "sha512-Cy5RfopxF1qhE+sds0XOMeKegT80NVV43JAMsD7Be9l/tjRPO5YzewOpQq8jUnOngI4GOiOgG2M7GB772hIVwA==",
       "dev": true,
       "requires": {
-        "yaml": "github:isaacs/yaml#built"
+        "yaml": "github:isaacs/yaml#bd3a3116f21910ab79635b535494609f8794084a"
       }
     },
     "tape": {
@@ -10085,7 +10085,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -10528,7 +10528,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "test:watch": "gaze 'clear && node test | tap-min' 'test/**/*.js' 'index.js' 'lib/**/*.js'",
     "test:coverage": "istanbul cover test",
     "test:coverage:upload": "istanbul-coveralls",
+    "validate:ts": "tsc --strict --target es6 index.d.ts",
+    "postvalidate:ts": "tsc --noEmit --strict --target es6 test/typescript-validate.ts",
     "presemantic-release": "npm run build",
     "semantic-release": "semantic-release"
   },
@@ -50,6 +52,7 @@
     "tap-min": "^2.0.0",
     "tap-spec": "^5.0.0",
     "tape": "^4.2.2",
+    "typescript": "^3.5.3",
     "uglify-js": "^3.0.0"
   },
   "release": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "postbuild": "uglifyjs dist/before-after-hook.js -mc > dist/before-after-hook.min.js",
     "pretest": "standard",
     "test": "npm run -s test:node | tap-spec",
+    "posttest": "npm run validate:ts",
     "test:node": "node test",
     "test:watch": "gaze 'clear && node test | tap-min' 'test/**/*.js' 'index.js' 'lib/**/*.js'",
     "test:coverage": "istanbul cover test",

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -1,0 +1,56 @@
+import { Hook, Collection, Singular } from '../index'
+
+// ************************************************************
+// THIS CODE IS NOT EXECUTED. IT IS JUST FOR TYPECHECKING
+// ************************************************************
+
+const _Collection = Hook.Collection
+const _Singular = Hook.Singular
+
+type Options = {
+  [key: string]: any
+  everything: number
+}
+
+const options: Options = {
+  everything: 42,
+  nothing: 0
+}
+
+const hookMethod = (options: Options): number => {
+  const sumOfNumbers = Object.keys(options)
+    .map(key => options[key])
+    .filter((v): v is number => typeof v === 'number')
+    .reduce((sum, num) => sum + num, 0)
+
+  return sumOfNumbers
+}
+
+const beforeHook = (_options: Options): void => {}
+const afterHook = (_result: number, _options: Options): void => {}
+const errorHook = (_error: any, _options: Options): void => {}
+const wrapHook = (hookMethod: any, options: Options): number => {
+  beforeHook(options)
+  const result = hookMethod(options)
+  afterHook(result, options)
+  return result
+}
+
+const hooks = new Collection()
+
+hooks.before('life', beforeHook)
+hooks.after('life', afterHook)
+hooks.error('life', errorHook)
+hooks.wrap('life', wrapHook)
+
+hooks('life', hookMethod)
+hooks(['life'], hookMethod)
+
+const hook = new Singular<Options, number>()
+
+hook.before(beforeHook)
+hook.after(afterHook)
+hook.error(errorHook)
+hook.wrap(wrapHook)
+
+hook(hookMethod, options)


### PR DESCRIPTION
**Example Usage**:

```ts
// Options type
type O = { [key: string]: any }

// return type
type R = number

const hook = new Singular<O, R>()

const hookMethod = async (options: O): Promise<R> => {
  return 42
}

hook(hookMethod, {})
```

-------

~With these changes, the following type definition [here](https://github.com/octokit/rest.js/blob/b30951f31a0b6d08cd050635f36a50c288d75537/scripts/templates/index.d.ts.tpl#L251-L256) can be expressed as:~

```ts
  hook: HookSingular<Octokit.HookOptions, Octokit.Response<any>, Octokit.HookError>
```

**Edit**: well, first it'll have to be changed to a singular hook ¯\_(ツ)_/¯

-------

resolves #61 (typings related issue)