### PR TITLE
fix: add `"main"` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "before-after-hook",
   "version": "0.0.0-development",
   "description": "asynchronous before/error/after hooks for internal functionality",
+  "main": "index.js",
   "files": [
     "index.js",
     "index.d.ts",


### PR DESCRIPTION
This fixes a bug trying to build `@octokit/core` in esinstall (and Skypack, by extension) 🙂 