### PR TITLE
fix(types): async hooks

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,9 +2,15 @@ type HookMethod<Options, Result> = (
   options: Options
 ) => Result | Promise<Result>
 
-type BeforeHook<Options> = (options: Options) => void
-type ErrorHook<Options, Error> = (error: Error, options: Options) => void
-type AfterHook<Options, Result> = (result: Result, options: Options) => void
+type BeforeHook<Options> = (options: Options) => void | Promise<void>
+type ErrorHook<Options, Error> = (
+  error: Error,
+  options: Options
+) => void | Promise<void>
+type AfterHook<Options, Result> = (
+  result: Result,
+  options: Options
+) => void | Promise<void>
 type WrapHook<Options, Result> = (
   hookMethod: HookMethod<Options, Result>,
   options: Options


### PR DESCRIPTION
I had no idea that, async hooks like this is supported:

```js
const hook = new Singular()

hook.before(async (options) => {
})
```

This PR fixes types for that use-case.