### PR TITLE
Revert wrong style fix in `examples/`

### DIFF
--- a/examples/authentication-example.md
+++ b/examples/authentication-example.md
@@ -15,9 +15,9 @@ authentication.sessions.add(credentials);
 The exposed hooks could be
 
 - `registration`  
-  invokedwhenauseraccountgetscreated
+  invoked when a user account gets created
 - `login`  
-  invokedwhenausertriestosignin
+  invoked when a user tries to sign in
 
 The implementation of the hooks could look like this:
 

--- a/examples/store-example.md
+++ b/examples/store-example.md
@@ -21,13 +21,13 @@ store.remove(id);
 The exposed hooks could be
 
 - `add`  
-  invokedwhenadocumentgetsadded
+  invoked when a document gets added
 - `update`  
-  invokedwhenadocumentgetsadded
+  invoked when a document gets updated
 - `remove`  
-  invokedwhenadocumentgetsadded
+  invoked when a document is removed
 - `save`  
-  invokedeachtimeadocumentgetssavedwithinthehookslistedabove.
+  invoked each time a document gets saved within the hooks listed above.
 
 The implementation of the hooks could look like this:
 


### PR DESCRIPTION
Spaces were removed by mistake in `examples/` in https://github.com/gr2m/before-after-hook/commit/c437f43a6c3dcc2ca3a6c49e94817da9af2092a4 .

Original:

https://github.com/gr2m/before-after-hook/blob/c2d4020456789c183a5f77b4d837f0099937d91a/examples/authentication-example.md?plain=1#L15-L20